### PR TITLE
Added NGINX configuration example and build command

### DIFF
--- a/nginx-configuration-example.conf
+++ b/nginx-configuration-example.conf
@@ -1,0 +1,7 @@
+server {
+    # ...
+	location /anon/ { # path 
+        root /path/to/project/baselocation; 
+		try_files $uri /anon/index.html; # try the file requested or the builded index.html
+	}
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "start-test": "PUBLIC_URL=http://localhost:3000/anon && react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "build-deploy": "react-app-rewired build && mv build anon"
   },
   "homepage": "/anon",
   "eslintConfig": {


### PR DESCRIPTION
To be able to run the project on a "deployment environment" we need to setup the static server to always send the `index.html` when the files don't exist.
This commit adds a build command that creates a build folder with the name `/anon/` (to work well with nginx without rewriting requests) and a example of the nginx configuration.